### PR TITLE
Updates for compatibility with Chrome 31

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,4 +1,5 @@
 {
+  "manifest_version": 2,
   "name": "Keyboard Shortcuts for Google Search™",
   "version": "0.1.1",
   "description": "Adds keyboard shortcuts to Google search result pages.",

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,10 @@
      "48": "icon/icon-48.png",
     "128": "icon/icon-128.png"
   },
+
+  "web_accessible_resources": [
+    "images/chevron.gif"
+  ],
             
   "content_scripts": [
     {


### PR DESCRIPTION
.crx wouldn't load in recent Chromes, and loading chevron image was denied.  Fixes here.

Cool extension, thanks for writing it!
